### PR TITLE
fix: add collection links to top collections

### DIFF
--- a/src/components/NFTCollectionTable/index.tsx
+++ b/src/components/NFTCollectionTable/index.tsx
@@ -12,6 +12,7 @@ import { RootState } from "../../store/store";
 import styled from "styled-components";
 import { Box } from "@mui/material";
 import { RankingI } from "../../types";
+import { Link } from "react-router-dom";
 
 const StyledImage = styled(Box)`
   width: 53px;
@@ -66,7 +67,14 @@ const NFTCollectionTable: React.FC<Props> = ({ rankings }) => {
               <StyledTableCell>
                 <StyledImage sx={{ backgroundImage: `url(${player.image})` }} />
               </StyledTableCell>
-              <StyledTableCell>{player.name}</StyledTableCell>
+              <StyledTableCell>
+                <Link
+                  style={{ textDecoration: "none", color: "inherit" }}
+                  to={`/collection/${player.collectionId}`}
+                >
+                  {player.name}
+                </Link>
+              </StyledTableCell>
               <StyledTableCell>
                 {player.floorPrice === 0
                   ? "-"

--- a/src/components/RankingList/index.tsx
+++ b/src/components/RankingList/index.tsx
@@ -272,11 +272,16 @@ const RankingsTable: React.FC<Props> = ({ rankings, selectedOption }) => {
                       }}
                     />
                     <AccountInfo>
-                      <AccountName className={isDarkTheme ? "dark" : "light"}>
-                        {filteredRankings[index]?.name
-                          ? filteredRankings[index].name
-                          : "Collection Name"}
-                      </AccountName>
+                      <Link
+                        style={{ textDecoration: "none" }}
+                        to={`/collection/${filteredRankings[index]?.collectionId}`}
+                      >
+                        <AccountName className={isDarkTheme ? "dark" : "light"}>
+                          {filteredRankings[index]?.name
+                            ? filteredRankings[index].name
+                            : "Collection Name"}
+                        </AccountName>
+                      </Link>
                       <AccountMetric>
                         <AccountMetricSubtext>Floor</AccountMetricSubtext>
                         <AccountMetricMaintext>


### PR DESCRIPTION
Make collection names clickable with link to collection page here:

<img width="1196" alt="Screenshot 2024-03-07 at 13 44 17" src="https://github.com/NautilusOSS/nautilus-interface/assets/23183451/ec6a9f02-a61a-4eb1-9510-9c08d613f858">
<img width="1197" alt="Screenshot 2024-03-07 at 13 38 30" src="https://github.com/NautilusOSS/nautilus-interface/assets/23183451/dbacaff2-9354-460b-8ea2-cdff9ac34b53">
