### PR TITLE
Handle missing staking contracts after withdraw

### DIFF
--- a/src/pages/Staking/components/PositionContainer/index.tsx
+++ b/src/pages/Staking/components/PositionContainer/index.tsx
@@ -322,7 +322,16 @@ const PositionContainer: React.FC = () => {
     queries: manualContractIds.map((contractId) => ({
       queryKey: ["stakingAccount", contractId, { includeRewards: true, includeWithdrawable: true }],
       queryFn: async () => {
-        const response = await axios.get(`${SCS_API}/app/${contractId}`);
+        const response = await axios.get(`${SCS_API}/app/${contractId}`).catch((error) => {
+          if (axios.isAxiosError(error) && error.response?.status === 404) {
+            return null;
+          }
+
+          throw error;
+        });
+
+        if (!response) return null;
+
         const appData = response.data;
         
         // Get creator from appInfo or try to find it from accounts endpoint
@@ -399,7 +408,7 @@ const PositionContainer: React.FC = () => {
   const manualContracts = useMemo(() => {
     return manualContractQueries
       .map((query) => query.data)
-      .filter((data): data is NonNullable<typeof data> => data !== undefined);
+      .filter((data): data is NonNullable<typeof data> => data != null);
   }, [manualContractQueries]);
 
   // Merge owned contracts with manually added contracts
@@ -622,10 +631,16 @@ const PositionContainer: React.FC = () => {
         stakingContracts={allStakingContracts?.slice(0, displayCount) || []}
         arc72Tokens={arc72TokenData?.slice(0, displayCount)}
         onRefresh={() => {
-          refetchStakingContract();
-          refetchArc72Token();
+          refetchStakingContract().catch((error) => {
+            console.warn("Failed to refresh owned staking contracts", error);
+          });
+          refetchArc72Token().catch((error) => {
+            console.warn("Failed to refresh staking position tokens", error);
+          });
           manualContractQueries.forEach((query) => {
-            query.refetch();
+            query.refetch().catch((error) => {
+              console.warn("Failed to refresh watched staking contract", error);
+            });
           });
         }}
       />

--- a/src/pages/Staking/components/PositionTokenRow/index.tsx
+++ b/src/pages/Staking/components/PositionTokenRow/index.tsx
@@ -458,7 +458,9 @@ const PositionTokenRow: React.FC<PositionTokenRowProps> = ({
         .sendRawTransaction(stxns as Uint8Array[])
         .do();
       await algosdk.waitForConfirmation(algodClient, txId, 4);
-      await refetch();
+      await refetch().catch((error) => {
+        console.warn("Staking position refetch failed after withdraw", error);
+      });
       toast.success("Successfully withdrawn funds");
       setIsWithdrawModalOpen(false);
       setWithdrawAmount(0);
@@ -798,7 +800,9 @@ const PositionTokenRow: React.FC<PositionTokenRowProps> = ({
         .do();
 
       await algosdk.waitForConfirmation(algodClient, txId, 4);
-      await refetch();
+      await refetch().catch((error) => {
+        console.warn("Staking position refetch failed after burn", error);
+      });
       setSuccessTxId(txId);
       setIsBurnModalOpen(false);
       party.confetti(document.body, {


### PR DESCRIPTION
## Summary
- treat watched staking contracts that return 404 as absent instead of letting them enter the table data
- filter null manual contract query results out of the merged staking contract list
- make post-withdraw and post-burn refetch failures non-blocking so confirmed transactions still close cleanly
- catch refresh failures per owned/manual source so one missing watched contract does not break the full staking refresh

Fixes #85.

## Verification
- `npm install --legacy-peer-deps --package-lock=false`
- `npm run build` currently fails on an existing unrelated missing dependency: `src/pages/CommunityChest/index.tsx` imports `recharts`, but `recharts` is not declared in `package.json`
- `npx tsc --noEmit --project tsconfig.json` currently reports pre-existing project-wide TypeScript errors; the run reaches the touched staking files and shows the repository already has broad type debt in the staking area


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved resilience when contracts or transaction data fail to load
  * Enhanced error recovery for transaction operations to prevent app crashes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NautilusOSS/nautilus-interface/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->